### PR TITLE
bug: PyTorch 1.1.0 is not compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In case you don't have an environment with GPUs to run PIFuHD, we offer Google C
 
 ## Requirements
 - Python 3
-- [PyTorch](https://pytorch.org/) tested on 1.1.0
+- [PyTorch](https://pytorch.org/) tested on 1.3.0
 - json
 - PIL
 - skimage


### PR DESCRIPTION
According to this [post](https://github.com/sniklaus/pytorch-spynet/issues/13#issuecomment-596901950), PyTorch introduced the option `align_corners` for `grid_sample` in version 1.3.0, so the project may not work correctly on 1.1.0, because an error:
```
grid_sample() got an unexpected keyword argument 'align_corners' 
```

To install PyTorch1.3.0 with conda:
```
conda install pytorch=1.3.0 torchvision cudatoolkit -c pytorch
```