### PR TITLE
falls back to CPU processing if CUDA not present

### DIFF
--- a/apps/recon.py
+++ b/apps/recon.py
@@ -142,10 +142,12 @@ def recon(opt, use_rect=False):
     start_id = opt.start_id
     end_id = opt.end_id
 
+    cuda = torch.device('cuda:%d' % opt.gpu_id if torch.cuda.is_available() else 'cpu')
+
     state_dict = None
     if state_dict_path is not None and os.path.exists(state_dict_path):
         print('Resuming from ', state_dict_path)
-        state_dict = torch.load(state_dict_path)    
+        state_dict = torch.load(state_dict_path, map_location=cuda)    
         print('Warning: opt is overwritten.')
         dataroot = opt.dataroot
         resolution = opt.resolution


### PR DESCRIPTION
Elegantly falls back to CPU mode if PyTorch not compiled with CUDA support or not detected compatible GPU.