### PR TITLE
Invalid pip package skimage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # to update just use `pip install -r requirements.txt --upgrade`
 pytorch
 Pillow                # PIL
-skimage
+scikit-mage
 tqdm
 opencv-python         # cv2
 trimesh


### PR DESCRIPTION
Invalid package detected in requirements.txt file: scimage is not a valid pip package. Note the actual name is scikit-image.