### PR TITLE
Invalid package name skimage replaced

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # to update just use `pip install -r requirements.txt --upgrade`
 pytorch
 Pillow                # PIL
-skimage
+scikit-image          #skimage
 tqdm
 opencv-python         # cv2
 trimesh


### PR DESCRIPTION
skimage is not a valid package on Pypi, the correct package name is scikit-image.