### PR TITLE
Add simple, cross-platform installation of dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*__pycache__*
+/checkpoints
+/results
+/.vscode
+/ffmpeg

--- a/apps/render_turntable.py
+++ b/apps/render_turntable.py
@@ -18,6 +18,9 @@ import cv2
 import os
 import argparse
 
+import ffmpeg
+import glob
+
 width = 512
 height = 512
 
@@ -122,8 +125,15 @@ for i, obj_path in enumerate(obj_files):
 
         cv2.imwrite(os.path.join(obj_root, 'rot_%04d.png' % cnt), 255*img)
         cnt += 1
-
-    cmd = 'ffmpeg -framerate 30 -i ' + obj_root + '/rot_%04d.png -vcodec libx264 -y -pix_fmt yuv420p -refs 16 ' + os.path.join(obj_root, file_name + '.mp4')
-    os.system(cmd)
-    cmd = 'rm %s/rot_*.png' % obj_root
-    os.system(cmd)
+    
+    # create video from image frames using ffmpeg
+    stream=ffmpeg.input(obj_root+'/rot_%04d.png')
+    stream=ffmpeg.output(stream,os.path.join(obj_root, file_name + '.mp4'), pix_fmt='yuv420p', vcodec='libx264', refs='16')
+    if sys.platform == 'win32':
+        # define ffmpeg location when using windows
+        ffmpeg.run(stream,cmd='C:/Code/pifuhd/ffmpeg/ffmpeg')
+    else:
+        ffmpeg.run(stream)
+    # remove image frames
+    for f in glob.glob('%s/rot_*.png' % obj_root):
+        os.remove(f)

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,0 +1,8 @@
+# This is a pip requirements file for optional packages used only for visualisation.
+# To install all these requirements:
+# 'pip install -r optional-requirements.txt'
+# Make sure you have pip installed!
+# To update just use 'pip install -r optional-requirements.txt --upgrade'
+trimesh
+PyOpenGL
+ffmpeg-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,9 @@
-#this is a requirement.txt file
-#to install all this requirements
-#`pip install -r requirements.txt`
-# make sure you have pip installed !!
-# to update just use `pip install -r requirements.txt --upgrade`
-pytorch
+# This is a pip requirements file.
+# To install all these requirements:
+# 'pip install -r requirements.txt'
+# Make sure you have pip installed!
+# To update just use 'pip install -r requirements.txt --upgrade'
 Pillow                # PIL
-scikit-image          #skimage
-tqdm
 opencv-python         # cv2
-trimesh
-PyOpenGL
-ffmpeg
-
+scikit-image          # skimage
+tqdm

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,4 +1,9 @@
+#!/bin/bash
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+# Set working directory to directory above this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR/../
 
 python -m apps.simple_test
 # python apps/clean_mesh.py -f ./results/pifuhd_final/recon

--- a/scripts/download_trained_model.sh
+++ b/scripts/download_trained_model.sh
@@ -1,4 +1,9 @@
+#!/bin/bash
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+# Set working directory to directory above this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR/../
 
 set -ex
 

--- a/scripts/setup_optional.sh
+++ b/scripts/setup_optional.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+# Set working directory to directory above this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR/../
+
+# Detect python version
+pyVersion=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)')
+if [[ -z "$pyVersion" ]]
+then
+	echo "Python not found" 
+	exit 1
+fi
+echo Python v$pyVersion found
+# Extract major minor version and remove dot
+[[ $pyVersion =~ ^[0-9]+\.[0-9]+ ]]
+pyVersionMajorMinor="${BASH_REMATCH[0]//./}"
+
+# Check FFMPEG is installed
+ffmpegVersionMessage=$(ffmpeg -version 2>&1)
+ffmpegFound=false
+if [[ -z "$ffmpegVersionMessage" ]]
+then
+	ffmpegFound=true
+	echo "ffmpeg found"
+	echo "$ffmpegVersionMessage"
+fi
+
+# OS specific commands
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+	# Using Windows bash with minGW or gygwin
+	
+	if [ "$ffmpegFound" = false ] ; then
+		# Check for ffmpeg exe in script path
+		if [ -f "ffmpeg/ffmpeg.exe" ]
+		then
+			echo "ffmpeg found at pifuhd/ffmpeg/ffmpeg.exe"
+		else
+			echo "ffmpeg not found. Will download from https://github.com/BtbN/FFmpeg-Builds"
+			# Download ffmpeg from BtbN auto build for windows
+			ffmpeglink=$(curl -s https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/latest \
+			| grep "browser_download_url.*-win64-gpl.zip" \
+			| cut -d : -f 2,3 \
+			| tr -d \" )
+			echo $ffmpeglink
+			curl -o ffmpeg.zip -L $ffmpeglink
+			# Extract ffmpeg to easy to read folder 'pifuhd/ffmpeg'
+			unzip ffmpeg.zip -d ffmpeg
+			rm ffmpeg.zip
+			cd ffmpeg
+			# Find folder name starting with ffmpeg*...
+			ffmpegFolder=$(find . -maxdepth 1 -type d -name 'ffmpeg*' -print -quit)
+			# Copy files out of oddly named folder into simple ffmpeg folder
+			cd $ffmpegFolder/bin
+			cp * ../../
+			cd ../..
+			rm -r $ffmpegFolder
+			cd ..
+		fi
+	fi
+
+	# Offical OpenGL pip is broken on windows so should use binary from here: https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopengl
+	# Download the correct wheel based on python version
+	# Check python version is one of the supported wheels (35,36,37,38,39)
+	if [[ "$pyVersionMajorMinor" -le "39" && "$pyVersionMajorMinor" -ge "35" ]]
+	then 
+		echo "Installing PyOpenGL..."
+		# Wheel files for 3.5,3.6,3.7 have filename with added 'm' e.g. cp35m rather than cp35
+		if [[ "$pyVersionMajorMinor" -le "39" && "$pyVersionMajorMinor" -ge "38" ]]
+		then
+			wheelfile="PyOpenGL-3.1.5-cp${pyVersionMajorMinor}-cp${pyVersionMajorMinor}-win_amd64.whl"
+		else
+			wheelfile="PyOpenGL-3.1.5-cp${pyVersionMajorMinor}-cp${pyVersionMajorMinor}m-win_amd64.whl"
+		fi
+		curl -o $wheelfile -L https://download.lfd.uci.edu/pythonlibs/z4tqcw5k/$wheelfile
+		# install wheel
+		python -m pip install $wheelfile
+		# delete wheel file after install
+		rm $wheelfile
+	else
+		echo "Invalid python version found"
+		echo "OpenGL python wheels only available for >= 3.5 <= 3.9"
+		exit 1
+	fi
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	# Using Linux (Assumes Ubuntu, Debian, Mint that use 'apt-get install')
+	
+	# Install ffmpeg if missing
+	if [ "$ffmpegFound" = false ] ; then
+		echo "Installing ffmpeg..."
+		sudo apt-get install ffmpeg
+	fi
+
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	# Using MacOSX (Assumes homebrew that uses 'brew install')
+
+	# Install ffmpeg if missing
+	if [ "$ffmpegFound" = false ] ; then
+		brew install ffmpeg
+	fi
+fi
+
+python -m pip install -r optional-requirements.txt

--- a/scripts/setup_required.sh
+++ b/scripts/setup_required.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+# Set working directory to directory above this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR/../
+
+# Detect cuda version
+cudaVersion=$(nvcc --version | grep "release" | awk '{print $6}' | cut -c2-)
+echo CUDA v$cudaVersion found
+# Extract major minor version and remove dot
+[[ $cudaVersion =~ ^[0-9]+\.[0-9]+ ]]
+cudaVersionMajorMinor="${BASH_REMATCH[0]//./}"
+
+# Install pytorch with detected cuda version
+if [[ "$cudaVersionMajorMinor" == "102" ]]
+then
+	# PyTorch 1.7.0 expects CUDA 10.2 so no addition to the versioning is required
+	python -m pip install torch===1.7.0 torchvision===0.8.1 -f https://download.pytorch.org/whl/torch_stable.html
+else
+	# Will add '+cuXXX' to version number e.g. torch===1.7.0+cu110 for cuda 11.0
+	python -m pip install torch===1.7.0+cu$cudaVersionMajorMinor torchvision===0.8.1+cu$cudaVersionMajorMinor -f https://download.pytorch.org/whl/torch_stable.html
+fi
+
+# OS specific commands
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+	# Using Windows bash with minGW or gygwin
+	
+	# Numpy needs to be installed before scikit-image can be downloaded
+	# Also bug in numpy 1.19.4 on windows so using 1.19.3 (see https://github.com/numpy/numpy/issues/17726)
+	python -m pip install numpy==1.19.3
+else
+	# Using MacOSX or Linux
+	
+	# Numpy needs to be installed before scikit-image can be downloaded
+	python -m pip install numpy
+fi
+
+python -m pip install -r requirements.txt


### PR DESCRIPTION
Split requirements into optional and required files. Added scripts to download and install dependencies automatically. 
Replaced os.system(cmd) in render_turntable.py with python native code.
Uses ffmpeg auto build repository [BtbN](https://github.com/BtbN/FFmpeg-Builds) on Windows.
Uses pyopengl prebuilt binaries from [University of California](https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopengl) for Windows due to known bug in latest official released binaries. 
Tested on Windows 10 with Python 3.8 & 3.7